### PR TITLE
typo s/nince/nine/

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1012,7 +1012,7 @@ many of which are independently developed and maintained. This makes threat
 modeling for the Web a complex challenge (See [The Web is
 Unversioned](https://www.w3.org/2001/tag/doc/the-web-is-unversioned/)).
 
-For this threat model, we think about the World Wide Web as just nince
+For this threat model, we think about the World Wide Web as just nine
 independent components: three human (user, website admin, and network
 operator), three in software (a browser, a DNS server, and a web server),
 and three legal persons (Website Application Providers, Internet Service

--- a/index.bs
+++ b/index.bs
@@ -15,7 +15,7 @@ Indent: 2
 Editor: Simone Onofri, w3cid 38211, W3C, simone@w3.org
 Editor: Joe Andrieu, w3cid 97261, Legendary Requirements https://legreq.com, joe@legreq.com
 Abstract:
-  This document describes when, why, and how to perform threat modeling during the development of a specification at the World Wide Web Consortium (W3C). This is designed to help specification developers understand threats and countermeasures from the beginning of collaboration and to document the model in the security considerations section.
+  This document describes when, why, and how to perform threat modeling during the development of a specification at the World Wide Web Consortium (W3C). This is designed to help specification developers understand threats and countermeasures from the beginning of collaboration and to document the model in the security considerations section.  
 
   This document is intended for threat modeling with the broadest definition of threat.
 Status text:

--- a/index.bs
+++ b/index.bs
@@ -16,7 +16,6 @@ Editor: Simone Onofri, w3cid 38211, W3C, simone@w3.org
 Editor: Joe Andrieu, w3cid 97261, Legendary Requirements https://legreq.com, joe@legreq.com
 Abstract:
   This document describes when, why, and how to perform threat modeling during the development of a specification at the World Wide Web Consortium (W3C). This is designed to help specification developers understand threats and countermeasures from the beginning of collaboration and to document the model in the security considerations section.  
-
   This document is intended for threat modeling with the broadest definition of threat.
 Status text:
   <p><em>This section describes the status of this document at the time of its publication. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.</em></p>

--- a/index.bs
+++ b/index.bs
@@ -12,7 +12,7 @@ Issue Tracking: GitHub https://github.com/w3c/threat-modeling-guide/issues
 Mailing List: public-security@w3.org
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-security/
 Indent: 2
-Editor: Simone Onofri, w3cid 38211, W3C Team, simone@w3.org
+Editor: Simone Onofri, w3cid 38211, W3C, simone@w3.org
 Editor: Joe Andrieu, w3cid 97261, Legendary Requirements https://legreq.com, joe@legreq.com
 Abstract:
   This document describes when, why, and how to perform threat modeling during the development of a specification at the World Wide Web Consortium (W3C). This is designed to help specification developers understand threats and countermeasures from the beginning of collaboration and to document the model in the security considerations section.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/elf-pavlik/threat-modeling-guide/pull/19.html" title="Last updated on Jun 17, 2026, 8:04 PM UTC (ec2e5f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/19/f549824...elf-pavlik:ec2e5f8.html" title="Last updated on Jun 17, 2026, 8:04 PM UTC (ec2e5f8)">Diff</a>