### PR TITLE
Removing the repetition of the type of threats

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -530,18 +530,6 @@ stakeholders to understand if their particular concerns are addressed.
 At the W3C, Working Groups develop threat models to capture and document
 threats related to a specification as it is expected to be deployed.
 
-Threats listed in W3C threat models should include:
-
-1. **Target Threats** which are explicitly addressed by specification
-   developers,
-2. **Implementation Threats** likely to impact implementations, but for
-   which normative constraints are deemed too restrictive,
-3. **External Threats** Known real-world or systemic risks that exist for
-   common use cases, but are recognized as out of scope for the modeled
-   version of the specification, and
-4. **Dependency Threats** inherited from other elements of the ecosystem,
-   and relevant to the specific use-cases.
-
 Specifications that define the Web offer significant extensibility and
 optionality, allowing implementers to make a wide range of choices that
 affect security, even when 100% conformant to the specification. Often spec


### PR DESCRIPTION
Addressing: https://github.com/w3c/threat-modeling-guide/issues/18


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/pull/23.html" title="Last updated on Apr 8, 2026, 4:34 PM UTC (b9e203d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/23/fb6d280...b9e203d.html" title="Last updated on Apr 8, 2026, 4:34 PM UTC (b9e203d)">Diff</a>