### PR TITLE
Update abstract to clarify threat modeling scope and outputs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,9 +15,9 @@ Indent: 2
 Editor: Simone Onofri, w3cid 38211, W3C https://w3.org, simone@w3.org
 Editor: Joe Andrieu, w3cid 97261, Legendary Requirements https://legreq.com, joe@legreq.com
 Abstract:
-  This document describes when, why, and how to perform threat modeling during the development of a specification at the World Wide Web Consortium (W3C). This is designed to help specification developers understand threats and countermeasures from the beginning of collaboration and to document the model in the security considerations section.
-
-  This document is intended for threat modeling with the broadest definition of threat.
+  This document explains how W3C Groups can use threat modeling during specification development to make explicit what is being specified, what can go wrong, who may be impacted, and how the specification addresses those threats.
+  It provides a practical structure for making this reasoning visible, helping specification developers, editors, and reviewers document the system under analysis, the relevant threats and harms, the assumptions being made, the responsibilities left to other actors, the responses chosen, and any residual risk.
+  This analysis can then be used to inform Security Considerations, Privacy Considerations, horizontal review, or a separate threat model referenced by the specification. In this Guide, “threat” is used broadly, including security and privacy threats, misuse or abuse of intended functionality, implementation and deployment risks, dependency and ecosystem threats, and harms to people or to the Web ecosystem.
 Status text:
   <p><em>This section describes the status of this document at the time of its publication. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.</em></p>
   <p>This Group Note Draft is endorsed by the Security Interest Group, but is not endorsed by W3C itself nor its Members.</p>


### PR DESCRIPTION
This PR refines the abstract so that it better explains why the Guide exists and what it helps Groups do.

The updated text frames threat modeling as a practical way to make security, privacy, abuse, and harm-related reasoning visible during specification development. It helps Groups document the system under analysis, the relevant threats and harms, the assumptions made, the responsibilities assigned or left to others, the responses chosen, and the residual risk.

It also clarifies that the Guide does not require a single framework, and that “threat” is intentionally used broadly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/pull/29.html" title="Last updated on Jun 23, 2026, 9:56 PM UTC (6504198)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/29/043b0ea...6504198.html" title="Last updated on Jun 23, 2026, 9:56 PM UTC (6504198)">Diff</a>