### PR TITLE
Add note on moving from harms to threat pathways

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -329,6 +329,33 @@ table.threat td.analysis-framework {
     "status": "Web guidance",
     "title": "Foundations of Assessing Harm (Harms modeling)"
   },
+  "W3C-LSP-THREAT-MODELING": {
+    "authors": ["Simone Onofri", "Giovanni Corti"],
+    "date": "20 October 2025",
+    "href": "https://www.w3.org/blog/2025/threat-modeling-with-lego-serious-play-building-your-digital-identity-threat/",
+    "id": "W3C-LSP-THREAT-MODELING",
+    "publisher": "W3C",
+    "status": "Blog post",
+    "title": "Threat Modeling with LEGO SERIOUS PLAY: Building your Digital Identity threat"
+  },
+  "THREAT-MODEL-DECENTRALIZED-CREDENTIALS": {
+    "authors": ["W3C"],
+    "date": "22 June 2026",
+    "href": "https://www.w3.org/TR/threat-model-decentralized-credentials/#harms",
+    "id": "THREAT-MODEL-DECENTRALIZED-CREDENTIALS",
+    "publisher": "W3C",
+    "status": "Group Draft Note",
+    "title": "Threat Model for Decentralized Credentials"
+  },
+  "INSTAR-HUMAN-RIGHTS-ICT-REPORT": {
+    "authors": ["Emilio Dávila González", "Paul Killeen", "Silvana Muscella", "et al."],
+    "date": "9 June 2026",
+    "href": "https://doi.org/10.5281/zenodo.20614147",
+    "id": "INSTAR-HUMAN-RIGHTS-ICT-REPORT",
+    "publisher": "Zenodo",
+    "status": "Post-event report",
+    "title": "Seminar on Human Rights and ICT Standardisation post-event report"
+  },
   "SOLOVE-PRIVACY": {
     "authors": ["Daniel J. Solove"],
     "date": "2006",
@@ -2376,6 +2403,23 @@ Starting from a harm does not make the harm itself a threat. For example,
 exclusion from a service is a harm. A socio-technical threat explains how a
 specified capability, implementation choice, deployment choice, or ecosystem
 practice can create the conditions for that exclusion.
+
+Note: Moving from harms to threats can be difficult when a harm is expressed in
+rights-related or socio-technical terms, for example dignity, fairness,
+transparency, non-discrimination, exclusion, or surveillance. The <cite>Seminar
+on Human Rights and ICT Standardisation post-event report</cite> identifies this
+translation gap between human-rights concepts and engineering requirements as a
+challenge for ICT standardization [[INSTAR-HUMAN-RIGHTS-ICT-REPORT]]. In W3C
+digital identity work, facilitated workshops have used the LEGO® SERIOUS PLAY®
+method in threat-modeling activities that considered security and human-rights
+threats, including harms-to-threat pathways
+[[W3C-LSP-THREAT-MODELING]]
+[[THREAT-MODEL-DECENTRALIZED-CREDENTIALS]]. The same facilitation technique can
+be used more generally when it helps participants make a model, assumption,
+threat, or harm concrete enough to discuss. The output of such a workshop still
+needs to be recorded as threat-model material: affected stakeholders, harms,
+system conditions or assumptions, threat pathways, and any responses, transfers,
+acceptances, or remaining threats.
 
 Use harms modeling, RFC 9620, and the W3C Self-Review Questionnaire:
 Societal Impact to identify relevant harms. Then map backward from those


### PR DESCRIPTION
This adds a note to the socio-technical harms section about the difficulty of moving from harms to concrete threat pathways.

The change:

- identifies the translation gap between rights-related concepts and engineering requirements;
- points to W3C digital identity work that used LEGO® SERIOUS PLAY® in facilitated threat-modeling workshops;
- clarifies that the same facilitation technique can also support security threat modeling when it helps make models, threats, or harms concrete enough to discuss;
- clarifies that workshop output still needs to be recorded as ordinary threat-modeling material.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/pull/31.html" title="Last updated on Jun 29, 2026, 9:53 PM UTC (eb341fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/threat-modeling-guide/31/ff57fa6...eb341fe.html" title="Last updated on Jun 29, 2026, 9:53 PM UTC (eb341fe)">Diff</a>